### PR TITLE
Always notify on failure.

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -1,15 +1,18 @@
 <div id="project_config_email_notifier" class="well">
   <fieldset>
     <legend>Email Notifier</legend>
-    <p>
-      By default, you will only recieve email notifications when the state of the build changes.
-      i.e it moves from a successful state to a failed state, or from a failed state to a successful state.
-      You can change this behaviour below.
-    </p>
-    <label class="checkbox">
-      <input type="checkbox" ng-model="config.always_notify" ng-change="changeAlwaysNotify()" />
-      Always send notification emails.
+
+    <label for="on-change">
+      <input id="on-change" type="radio" ng-model="config.notify" value="on-change">
+      <span>Notify on state change</span>
     </label>
-    <p class="help-text">When set, you will always recieve notifications when a build completes, regardless of its state change.</p>
+    <label for="always">
+      <input id="always" type="radio" ng-model="config.notify" value="always">
+      <span>Notify on every build</span>
+    </label>
+    <label for="noisy-fail">
+      <input id="noisy-fail" type="radio" ng-model="config.notify" value="noisy-fail">
+      <span>Notify on all failures and first success after failure</span>
+    </label>
   </fieldset>
 </div>

--- a/config/config.js
+++ b/config/config.js
@@ -3,11 +3,13 @@ app.controller('EmailNotifierCtrl', ['$scope', function ($scope) {
 
   $scope.config = $scope.pluginConfig('emailnotifier')
 
-  $scope.changeAlwaysNotify = function () {
-    $scope.saving = true
-    $scope.pluginConfig('emailnotifier', $scope.config, function () {
-      $scope.saving = false
-    })
-  }
+  $scope.$watch('config.notify', function(newValue, oldValue) {
+    if (newValue !== oldValue) {
+      $scope.saving = true;
+      $scope.pluginConfig('emailnotifier', $scope.config, function () {
+        $scope.saving = false
+      })
+    }
+  });
 
 }]);

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -32,11 +32,7 @@ module.exports = function (job, context, callback) {
       // Send email if this is the first ever job for this project, or if the build was a failure,
       // or if the previous build was a failure (first success) or if always notify is set for this project
 
-      if (!previousJob || {
-        'on-change': job.success !== previousJob.success,
-        'always': true,
-        'noisy-fail': !job.success || !previousJob.success
-      }[pluginConfig.notify || 'noisy-fail']) {
+      if (shouldEmail(pluginConfig.notify, job, previousJob)) {
         sendEmail(job, callback)
       } else {
         if (callback) callback(null, { state: 'didNotSend' })
@@ -47,4 +43,12 @@ module.exports = function (job, context, callback) {
 
 function determineSuccess(job) {
   return job.test_exitcode === 0 ? true : false
+}
+
+function shouldEmail(config, currentJob, previousJob) {
+  return !previousJob || {
+      'on-change': currentJob.success !== previousJob.success,
+      'always': true,
+      'noisy-fail': !currentJob.success || !previousJob.success
+    }[config || 'noisy-fail'];
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -31,7 +31,12 @@ module.exports = function (job, context, callback) {
 
       // Send email if this is the first ever job for this project, or if the build was a failure,
       // or if the previous build was a failure (first success) or if always notify is set for this project
-      if (pluginConfig.always_notify || !previousJob || !job.success || !previousJob.success) {
+
+      if (!previousJob || {
+        'on-change': job.success !== previousJob.success,
+        'always': true,
+        'noisy-fail': !job.success || !previousJob.success
+      }[pluginConfig.notify || 'noisy-fail']) {
         sendEmail(job, callback)
       } else {
         if (callback) callback(null, { state: 'didNotSend' })

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -29,9 +29,9 @@ module.exports = function (job, context, callback) {
       var pluginConfig = context.pluginConfig
       , sendEmail = createMailer(context)
 
-      // Send email if this is the first ever job for this project, or if the state of the build has changed
-      // or if always notify is set for this project
-      if (pluginConfig.always_notify || !previousJob || job.success !== previousJob.success) {
+      // Send email if this is the first ever job for this project, or if the build was a failure,
+      // or if the previous build was a failure (first success) or if always notify is set for this project
+      if (pluginConfig.always_notify || !previousJob || !job.success || !previousJob.success) {
         sendEmail(job, callback)
       } else {
         if (callback) callback(null, { state: 'didNotSend' })

--- a/test/test-email-notifier.js
+++ b/test/test-email-notifier.js
@@ -40,40 +40,40 @@ describe('Email Notifier', function () {
 
   it('should not break when no callback is set', function () {
     var job = createJob(0)
-      , context = createContext([job], { always_notify: true })
+      , context = createContext([job], { notify: 'always' })
     handler(job, context)
   })
 
-  it('should send success email when always_notify is true and job exit code is zero', function (done) {
+  it('should send success email when notify is "always" and job exit code is zero', function (done) {
     var job = createJob(0)
-      , context = createContext([job], { always_notify: true })
+      , context = createContext([job], { notify: 'always' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('successSent')
       done()
     })
   })
 
-  it('should send success email when always_notify is true and job exit code is > zero', function (done) {
+  it('should send success email when notify is "always" and job exit code is > zero', function (done) {
     var job = createJob(1)
-      , context = createContext([job], { always_notify: true })
+      , context = createContext([job], { notify: 'always' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('failureSent')
       done()
     })
   })
 
-  it('should send success email when always_notify is false and there is no previous job', function (done) {
+  it('should send success email when notify is "on-change" and there is no previous job', function (done) {
     var job = createJob(0)
-      , context = createContext([job], { always_notify: false })
+      , context = createContext([job], { notify: 'on-change' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('successSent')
       done()
     })
   })
 
-  it('should send success email when always_notify is false and job state has changed', function (done) {
+  it('should send success email when notify is "on-change" and job state has changed', function (done) {
     var job = createJob(0)
-      , context = createContext([job, createJob(1)], { always_notify: false })
+      , context = createContext([job, createJob(1)], { notify: 'on-change' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('successSent')
       done()
@@ -82,7 +82,7 @@ describe('Email Notifier', function () {
 
   it('should not send any emails when job state has not changed (both failed)', function (done) {
     var job = createJob(1)
-      , context = createContext([job, createJob(1)], { always_notify: false })
+      , context = createContext([job, createJob(1)], { notify: 'on-change' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('didNotSend')
       done()
@@ -91,7 +91,7 @@ describe('Email Notifier', function () {
 
   it('should not send any emails when job state has not changed (both failed, different codes)', function (done) {
     var job = createJob(1)
-      , context = createContext([job, createJob(2)], { always_notify: false })
+      , context = createContext([job, createJob(2)], { notify: 'on-change' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('didNotSend')
       done()
@@ -100,7 +100,34 @@ describe('Email Notifier', function () {
 
   it('should not send any emails when job state has not changed (both successful)', function (done) {
     var job = createJob(0)
-      , context = createContext([job, createJob(0)], { always_notify: false })
+      , context = createContext([job, createJob(0)], { notify: 'on-change' })
+    handler(job, context, function (error, response) {
+      expect(response.state).to.be('didNotSend')
+      done()
+    })
+  })
+
+  it('should send emails when job state has not changed and notify is noisy-fail (both failed)', function (done) {
+    var job = createJob(1)
+      , context = createContext([job, createJob(1)], { notify: 'noisy-fail' })
+    handler(job, context, function (error, response) {
+      expect(response.state).to.be('failureSent')
+      done()
+    })
+  })
+
+  it('should send emails when job state has not changed and notify is noisy-fail (both failed, different codes)', function (done) {
+    var job = createJob(1)
+      , context = createContext([job, createJob(2)], { notify: 'noisy-fail' })
+    handler(job, context, function (error, response) {
+      expect(response.state).to.be('failureSent')
+      done()
+    })
+  })
+
+  it('should not send any emails when job state has not changed and notify is noisy-fail (both successful)', function (done) {
+    var job = createJob(0)
+      , context = createContext([job, createJob(0)], { notify: 'noisy-fail' })
     handler(job, context, function (error, response) {
       expect(response.state).to.be('didNotSend')
       done()
@@ -123,7 +150,7 @@ describe('Email Notifier', function () {
         , { email: 'test2@example.com' }
         , { email: 'test3@example.com' }
         ]
-      , context = createContext([job, createJob(0)], { always_notify: true }, collaborators)
+      , context = createContext([job, createJob(0)], { notify: 'always' }, collaborators)
     handler(job, context, function (error, response) {
       expect(response.state).to.be('successSent')
       expect(response.numEmailsSent).to.be(3)

--- a/test/test-email-notifier.js
+++ b/test/test-email-notifier.js
@@ -116,7 +116,7 @@ describe('Email Notifier', function () {
     })
   })
 
-  it('should send emails when job state has not changed and notify is noisy-fail (both failed, different codes)', function (done) {
+  it('should send emails when job state has not changed (noisy-fail, both failed, different codes)', function (done) {
     var job = createJob(1)
       , context = createContext([job, createJob(2)], { notify: 'noisy-fail' })
     handler(job, context, function (error, response) {
@@ -125,7 +125,7 @@ describe('Email Notifier', function () {
     })
   })
 
-  it('should not send any emails when job state has not changed and notify is noisy-fail (both successful)', function (done) {
+  it('should not send any emails when job state has not changed (noisy-fail, both successful)', function (done) {
     var job = createJob(0)
       , context = createContext([job, createJob(0)], { notify: 'noisy-fail' })
     handler(job, context, function (error, response) {


### PR DESCRIPTION
Perhaps a philosophical difference. I think failures should be noisy, but consecutive successes should be quiet. I guess the less lazy option would be to add config for three settings:

- email on changed state
- email on every build
- email on every failure, and first success after failure